### PR TITLE
Fix: Increase map name text size and stabilize grid alignment

### DIFF
--- a/src/components/studio/MapPoolElement.module.css
+++ b/src/components/studio/MapPoolElement.module.css
@@ -14,7 +14,7 @@
 
 .playerMapGrid {
   display: grid;
-  grid-template-columns: repeat(5, auto);
+  grid-template-columns: repeat(5, 250px);
   grid-template-rows: repeat(4, auto);
   grid-auto-flow: column;
   grid-gap: 8px;
@@ -62,7 +62,7 @@
 
 .mapName {
   font-family: 'Cinzel', serif; /* from BoXSeriesOverview */
-  font-size: 0.9em; /* Relative to parent's dynamicFontSize */
+  font-size: 1.6em; /* Changed from 0.9em */
   text-align: center;
   white-space: nowrap;
   overflow: hidden;


### PR DESCRIPTION
This commit addresses your feedback to:
1. Increase the font size of map names for better legibility.
2. Ensure the map grid for each player consistently aligns from the bottom-left (P1) or bottom-right (P2) of their designated area, regardless of the number of maps being displayed.

Changes:
- In `MapPoolElement.module.css`:
    - Increased `font-size` for the `.mapName` class from `0.9em` to `1.6em`.
    - Changed `grid-template-columns` for `.playerMapGrid` from `repeat(5, auto)` to `repeat(5, 250px)`. This gives each column a fixed width, matching the map item width, which prevents the grid from shrinking or shifting its alignment when fewer than 5 columns of maps are present.

Map item dimensions remain 250x160px with `background-size: cover`.