### PR TITLE
feat: Add 'Hide Civs' option to BoXSeriesOverviewElement

### DIFF
--- a/src/components/studio/BoXSeriesOverviewElement.tsx
+++ b/src/components/studio/BoXSeriesOverviewElement.tsx
@@ -28,6 +28,7 @@ const BoXSeriesOverviewElement: React.FC<BoXSeriesOverviewElementProps> = ({ ele
     showCivNames = true,  // Default from element prop
     showMapNames = true,  // Default from element prop
     gameEntrySpacing = 10, // Default from element prop, store will set initial 10
+    hideCivs = false, // Destructure hideCivs prop
   } = element;
 
   // const [failedImageFallbacks, setFailedImageFallbacks] = useState<Set<string>>(new Set()); // Removed
@@ -78,10 +79,12 @@ const BoXSeriesOverviewElement: React.FC<BoXSeriesOverviewElementProps> = ({ ele
   // The fontFamily for the overall element is set on styles.baseElement,
   // so it should cascade unless overridden here.
   const gameImageRowDynamicStyle: React.CSSProperties = {
-    gridTemplateColumns: (pivotInternalOffset && pivotInternalOffset > 0)
-      ? `1fr ${pivotInternalOffset}px auto ${pivotInternalOffset}px 1fr`
-      : '1fr auto 1fr',
-    // fontFamily: fontFamily, // fontFamily is now on the baseElement, inherited unless overridden
+    gridTemplateColumns: hideCivs
+      ? 'auto' // If civs are hidden, map column takes its own width, centered by grid container
+      : (element.pivotInternalOffset && element.pivotInternalOffset > 0)
+        ? `1fr ${element.pivotInternalOffset}px auto ${element.pivotInternalOffset}px 1fr`
+        : '1fr auto 1fr',
+    // fontFamily is inherited
   };
 
   // Dynamic styles for images, setting their unscaled width and height.
@@ -169,6 +172,7 @@ const BoXSeriesOverviewElement: React.FC<BoXSeriesOverviewElementProps> = ({ ele
             </div>
            <div className={styles.gameImageRow} style={gameImageRowDynamicStyle}>
               {/* Left civilization display. */}
+              {!hideCivs && (
               <div className={`${styles.civCell} ${styles.leftCivCell}`}>
             <div
               key={hostCivKey + '-container'}
@@ -183,9 +187,10 @@ const BoXSeriesOverviewElement: React.FC<BoXSeriesOverviewElementProps> = ({ ele
               )}
             </div>
           </div>
+          )}
 
           {/* Spacer element, shown if pivotInternalOffset dictates a space. */}
-          {(pivotInternalOffset && pivotInternalOffset > 0) && <div className={styles.spacer}></div>}
+          {!hideCivs && (pivotInternalOffset && pivotInternalOffset > 0) && <div className={styles.spacer}></div>}
 
           {/* Map display. */}
           <div className={styles.mapCell}>
@@ -204,9 +209,10 @@ const BoXSeriesOverviewElement: React.FC<BoXSeriesOverviewElementProps> = ({ ele
           </div>
 
           {/* Spacer element, shown if pivotInternalOffset dictates a space. */}
-          {(pivotInternalOffset && pivotInternalOffset > 0) && <div className={styles.spacer}></div>}
+          {!hideCivs && (pivotInternalOffset && pivotInternalOffset > 0) && <div className={styles.spacer}></div>}
 
           {/* Right civilization display. */}
+          {!hideCivs && (
           <div className={`${styles.civCell} ${styles.rightCivCell}`}>
             <div
               key={guestCivKey + '-container'}
@@ -221,6 +227,7 @@ const BoXSeriesOverviewElement: React.FC<BoXSeriesOverviewElementProps> = ({ ele
               )}
             </div>
           </div>
+          )}
            </div> {/* End of gameImageRow */}
         </div>
       )})}

--- a/src/components/studio/SettingsPanel.tsx
+++ b/src/components/studio/SettingsPanel.tsx
@@ -111,6 +111,16 @@ const SettingsPanel: React.FC<SettingsPanelProps> = ({ selectedElement, onClose 
            onChange={(e) => handleSettingChange('showMapNames', e.target.checked)}
          />
        </div>
+       <div style={settingRowStyle}>
+         <label htmlFor="boxHideCivsCheckbox" style={labelStyle}>Hide Civs:</label>
+         <input
+           type="checkbox"
+           id="boxHideCivsCheckbox"
+           style={checkboxStyle}
+           checked={selectedElement.hideCivs || false} // Default to false if undefined
+           onChange={(e) => handleSettingChange('hideCivs', e.target.checked)}
+         />
+       </div>
         <div style={{ marginBottom: '12px' }}> {/* Game Spacing Slider from previous step */}
           <label
             htmlFor="boxGameSpacingSlider"

--- a/src/store/draftStore.ts
+++ b/src/store/draftStore.ts
@@ -1501,6 +1501,7 @@ const useDraftStore = create<DraftStore>()(
                 borderColor: 'transparent',
                 scale: 1,
                 isPivotLocked: false,
+                hideCivs: false, // Added hideCivs default
                 // No showName or showScore here
               };
             } else if (elementType === "ScoreOnly") {

--- a/src/types/draft.ts
+++ b/src/types/draft.ts
@@ -78,6 +78,7 @@ export interface StudioElement {
   showCivNames?: boolean;  // For toggling civ names on civ selectors
   showMapNames?: boolean;  // For toggling map names on map selectors
   gameEntrySpacing?: number; // Vertical spacing between game entries in BoX overview
+  hideCivs?: boolean; // New property for BoXSeriesOverview to hide civs
   // showName and showScore removed
   [key: string]: any;
   player1MapPool?: MapItem[];


### PR DESCRIPTION
This commit introduces a new "Hide Civs" option to the Element Settings for the `BoXSeriesOverviewElement`. When this option is enabled, the side columns displaying player civilizations will be hidden, leaving only the central column with the map and the "Game X" title.

Changes include:

1.  **Type Definition (`src/types/draft.ts`):**
    *   Added `hideCivs?: boolean;` to the `StudioElement` interface.

2.  **Store Update (`src/store/draftStore.ts`):**
    *   In the `addStudioElement` action, `BoXSeriesOverviewElement`
        instances are now created with a default `hideCivs: false` property.

3.  **Component Logic (`src/components/studio/BoXSeriesOverviewElement.tsx`):**
    *   The component now destructures the `hideCivs` prop.
    *   The rendering of the left and right civilization cells (and associated
        pivot spacers) is conditional based on the `hideCivs` value.
    *   The `gridTemplateColumns` style for the game row is dynamically
        adjusted. If civs are hidden, it simplifies to `'auto'` to allow
        the map column to occupy the central space.

4.  **Settings Panel UI (`src/components/studio/SettingsPanel.tsx`):**
    *   A new "Hide Civs" checkbox has been added to the settings
        section for `BoXSeriesOverviewElement`.
    *   This checkbox controls the `hideCivs` property of the selected
        element.

This feature provides you with more flexibility in customizing the visual presentation of the BoX Series Overview.