### PR TITLE
Refactor pivot-locked elements to prevent horizontal shifting.

### DIFF
--- a/src/components/studio/GeneralElements.module.css
+++ b/src/components/studio/GeneralElements.module.css
@@ -86,7 +86,6 @@
   box-sizing: border-box;
   padding: 5px; /* Overall padding for the grid itself */
   transition: transform 0.2s ease-out;
-  width: 100%;
 }
 
 .player1CivGrid {

--- a/src/components/studio/PickedCivsElement.tsx
+++ b/src/components/studio/PickedCivsElement.tsx
@@ -71,45 +71,35 @@ const PickedCivsElement: React.FC<PickedCivsElementProps> = ({ element, isBroadc
             }} />
         )}
       <div
-        style={{
-          position: 'absolute',
-          right: '50%',
-          transform: `translateX(${p1TranslateX}px)`,
-        }}
+        className={`${styles.playerCivGrid} ${styles.player1CivGrid}`}
+        style={{ transform: `translateX(${p1TranslateX}px)` }}
       >
-        <div className={`${styles.playerCivGrid} ${styles.player1CivGrid}`}>
-          {player1Civs.map((civ, index) => (
-            <CivItem
-              key={`p1-pick-${index}-${civ.name}`}
-              civName={civ.name}
-              civImageUrl={civ.imageUrl}
-              status="picked"
-              element={element}
-              identifier={`pick-host-${index}`}
-            />
-          ))}
-        </div>
+        {player1Civs.map((civ, index) => (
+          <CivItem
+            key={`p1-pick-${index}-${civ.name}`}
+            civName={civ.name}
+            civImageUrl={civ.imageUrl}
+            status="picked"
+            element={element}
+            identifier={`pick-host-${index}`}
+          />
+        ))}
       </div>
 
       <div
-        style={{
-          position: 'absolute',
-          left: '50%',
-          transform: `translateX(${p2TranslateX}px)`,
-        }}
+        className={`${styles.playerCivGrid} ${styles.player2CivGrid}`}
+        style={{ transform: `translateX(${p2TranslateX}px)` }}
       >
-        <div className={`${styles.playerCivGrid} ${styles.player2CivGrid}`}>
-          {player2Civs.map((civ, index) => (
-            <CivItem
-              key={`p2-pick-${index}-${civ.name}`}
-              civName={civ.name}
-              civImageUrl={civ.imageUrl}
-              status="picked"
-              element={element}
-              identifier={`pick-guest-${index}`}
-            />
-          ))}
-        </div>
+        {player2Civs.map((civ, index) => (
+          <CivItem
+            key={`p2-pick-${index}-${civ.name}`}
+            civName={civ.name}
+            civImageUrl={civ.imageUrl}
+            status="picked"
+            element={element}
+            identifier={`pick-guest-${index}`}
+          />
+        ))}
       </div>
     </div>
   );


### PR DESCRIPTION
The `maps`, `picked civs`, and `banned civs` elements would jump horizontally when changing presets, especially on different screen resolutions. This was caused by an unstable layout calculation when the number of items in the element changed.

This commit addresses the issue by:
1. Unifying the layout for all three elements (`PickedCivsElement`, `BannedCivsElement`, `MapsElement`) to use a consistent flexbox-based approach. `PickedCivsElement` was previously using absolute positioning, which has been removed.
2. Removing `width: 100%` from the `.playerCivGrid` style in `GeneralElements.module.css`.

Previously, the grids were forced to 100% width, causing them to overlap. They were then pushed apart with transforms. This led to unpredictable visual shifts when the content width changed.

By removing the fixed width, the grids now size to their content. The parent flex container with `justify-content: center` correctly centers the two grids as a group. The `transform` then creates a stable gap between them. This ensures that as the content changes, the grids expand and contract symmetrically around the central pivot point, eliminating the horizontal jump.